### PR TITLE
Improve enum interop

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,26 @@ cauto^cglfw.GetMouseButton(self.window, button) == 1
 tells the compiler how `cglfw.GetMouseButton(self.window, button)` should be
 generated and has the same semantics as Nim's `importcpp` pragma.
 
+### Enums
+
+For working with C/C++ enums, one can use the `cenum` pragma like so:
+
+```nim
+type CPP_ENUM* {.cenum.} = object
+```
+
+Although enums can be emulated using `CClass` and static methods, `cenum`
+provides better checking of enum semantics and produces better C/C++ code for
+enums. By default, enum field access results in an expansion similar to the
+following:
+
+```nim
+let enumValue = cauto^CPP_ENUM.MEMBER_1
+# generates `CPP_ENUM enumValue = CPP_ENUM_MEMBER_1`
+```
+
+Custom code generation for enums can be achieved using `cgen` as well.
+
 ## Gotchas
 
 ### Unary operations

--- a/src/cinterop/decls.nim
+++ b/src/cinterop/decls.nim
@@ -7,7 +7,13 @@ import ./private/pragmas
 import ./private/types
 import ./private/utils
 
-export CArray, CClass, CConst, CEnum, CRef, CString, cgen
+export CArray
+export CClass
+export CConst
+export CEnum
+export CRef
+export CString
+export cgen
 
 proc errorCDecl(sym: NimNode) {.compileTime.} =
   error("invalid C/C++ declaration: " & sym.repr, sym)
@@ -41,7 +47,7 @@ proc genDecl[T](
 
     result.add(node)
 
-macro concatHeaderStrings(str1, str2: static[string]): string =
+macro concatHeaderStrings(str1, str2: static string): string =
   let str1 = if not str1.startsWith("<"):
       "#include \"" & str1 & "\""
     else:
@@ -67,7 +73,7 @@ proc applyHeaderPragmaNode(pragma: NimNode, path: string) =
   else:
     addPathToHeaderNode(pragma[headerIdx], path)
 
-macro concatImportStrings(str1, str2: static[string]): string =
+macro concatImportStrings(str1, str2: static string): string =
   if not str2.startsWith('('):
     # add scope iff C code is not parenthesized
     var importParts = split(str2, "::")
@@ -116,7 +122,7 @@ proc applyImportPragmaNode(pragma, node: NimNode; cscope = "") =
 
   addScopeToPragmaNode(pragmaNode, cscope)
 
-macro csource*(path: static[string], code: untyped{nkStmtList}) =
+macro csource*(path: static string, code: untyped{nkStmtList}) =
   genDecl(code, path, ["cnamespace", "cscope"]) do (
       node, pragma: NimNode,
       path: string) -> void:

--- a/src/cinterop/decls.nim
+++ b/src/cinterop/decls.nim
@@ -10,9 +10,9 @@ import ./private/utils
 export CArray
 export CClass
 export CConst
-export CEnum
 export CRef
 export CString
+export cenum
 export cgen
 
 proc errorCDecl(sym: NimNode) {.compileTime.} =

--- a/src/cinterop/private/pragmas.nim
+++ b/src/cinterop/private/pragmas.nim
@@ -1,1 +1,30 @@
+import std/macros
+
+import ./types
+import ./utils
+
 template cgen*(ccode: string) {.pragma.}
+
+macro cenum*(def: untyped{nkTypeDef}) =
+  var name = def[0][0]
+  if name.kind == nnkPostfix:
+    name = name[1]
+
+  if def[1].kind == nnkGenericParams:
+    error("invalid C/C++ declaration: " &
+          name.repr & " cannot be generic", name)
+  if def[^1][1].kind == nnkOfInherit:
+    error("invalid C/C++ declaration: " &
+          name.repr & " cannot inherit", name)
+  if def[^1][^1].kind == nnkRecList:
+    error("invalid C/C++ declaration: " &
+          name.repr & " cannot contain fields", name)
+
+  result = def
+
+  let cgenIndex = result[0][^1].pragmaNodeIndexOf"cgen"
+  if cgenIndex == -1:
+    result[0][^1].add(newColonExpr(bindSym"cgen", newLit"('*1_$1)"))
+
+  result[0][^1].add(ident"final")
+  result[^1][1] = nnkOfInherit.newTree(bindSym"CEnum")

--- a/src/cinterop/private/pragmas.nim
+++ b/src/cinterop/private/pragmas.nim
@@ -18,7 +18,8 @@ macro cenum*(def: untyped{nkTypeDef}) =
           name.repr & " cannot inherit", name)
   if def[^1][^1].kind == nnkRecList:
     error("invalid C/C++ declaration: " &
-          name.repr & " cannot contain fields", name)
+          name.repr & " cannot contain fields; " &
+          "use procs to define enum fields", name)
 
   result = def
 

--- a/src/cinterop/private/utils.nim
+++ b/src/cinterop/private/utils.nim
@@ -3,7 +3,7 @@ import std/macros
 
 proc pragmaNodeIndexOf*(pragma: NimNode, name: string): int =
   result = -1
-  for i, node in enumerate(pragma.children):
+  for i, node in enumerate pragma:
     if node.kind == nnkIdent:
       if node.eqIdent(name):
         result = i
@@ -12,3 +12,39 @@ proc pragmaNodeIndexOf*(pragma: NimNode, name: string): int =
       if $node[0] == name:
         result = i
         break
+
+proc searchNodeKind*(node: NimNode, kind: NimNodeKind): NimNode =
+  if node.kind == kind:
+    result = node
+  elif node.kind notin AtomicNodes:
+    for child in node:
+      result = child.searchNodeKind(kind)
+      if result != nil:
+        break
+
+macro hasField*(base: typed, field: untyped): bool =
+  result = newLit false
+  for fieldNode in base.getTypeImpl[2]:
+    if fieldNode[0].eqIdent(field):
+      result = newLit true
+      break
+
+template isCallable*(base, field: untyped, args: varargs[untyped]): bool =
+  when declared(field):
+    # TODO: Avoid using `compiles`
+    when varargsLen(args) > 0:
+      compiles(field(base, args))
+    else:
+      compiles(field(base))
+  else:
+    false
+
+macro getPragmaContainerType*(Type: type): type =
+  result = Type
+  if result.kind != nnkSym:
+    if result.typeKind == ntyTypeDesc and
+        result.kind notin {nnkStmtListExpr, nnkStmtListType}:
+      result = result[1].getTypeInst
+      result = getAst getPragmaContainerType(result)
+    else:
+      result = result[0]

--- a/tests/tcinterop.nim
+++ b/tests/tcinterop.nim
@@ -9,7 +9,7 @@ import ./tcinterop/simple
 
 import cinterop/exprs
 
-template should(description: static[string], body: untyped) =
+template should(description: static string, body: untyped) =
   proc test() {.genSym.} = body
   test()
 

--- a/tests/tcinterop/simple.nim
+++ b/tests/tcinterop/simple.nim
@@ -16,7 +16,7 @@ csource CurrentDir & "/simple.hpp":
     cscope CppClass:
       type CppNestedClass* = object of CClass
 
-    type CPP_ENUM* {.cgen:"'*1_$1".} = object of CEnum
+    type CPP_ENUM* {.cenum cgen:"'*1_$1".} = object
 
     proc method1*(self: CppClass, arg: cint): cint
     converter method3*(self: CppClass): cint


### PR DESCRIPTION
Removes public export of `CEnum`, which is replaced by the `cenum` pragma, providing better semantic checking and defaults.